### PR TITLE
refactor: separar endpoint de subida de formularios (paso crítico)

### DIFF
--- a/carrera_academica/urls.py
+++ b/carrera_academica/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
     path('ca/<int:pk>/archivar/', views.archivar_ca_view, name='archivar_ca'),
     path('ca/<int:pk>/gestionar-archivada/', views.gestionar_ca_archivada_view, name='gestionar_ca_archivada'),
     path('formulario/<int:pk>/borrar-archivo/', views.borrar_archivo_formulario_view, name='borrar_archivo_formulario'),
+    path(
+        'expediente/<int:ca_pk>/formulario/<int:formulario_pk>/subir/',
+        views.subir_formulario_view,
+        name='subir_formulario',
+    ),
     # ===== JURADOS =====
     path('jurados/', views.lista_jurados_view, name='lista_jurados'),
     path('jurados/crear/', views.crear_jurado_view, name='crear_jurado'),

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -196,26 +196,6 @@ def dashboard_ca_view(request):
 @login_required
 def detalle_ca_view(request, pk):
     ca = get_object_or_404(CarreraAcademica.objects.with_full_detail(), pk=pk)
-
-    if request.method == "POST":
-        formulario_id = request.POST.get("formulario_id")
-        archivo = request.FILES.get("archivo")
-
-        if formulario_id and archivo:
-            formulario = ca.formularios.get(pk=formulario_id)
-            if formulario.archivo:
-                formulario.archivo.delete(save=False)
-            formulario.archivo = archivo
-            formulario.estado = "ENT"
-            formulario.fecha_entrega = timezone.now()
-            formulario.save()
-            messages.success(
-                request,
-                f"Se subió el archivo para el formulario {formulario.tipo_formulario}.",
-            )
-
-        return redirect("carrera_academica:detalle_ca", pk=ca.pk)
-
     contexto = {
         "ca": ca,
         "form_resolucion": ResolucionForm(),
@@ -223,6 +203,36 @@ def detalle_ca_view(request, pk):
         **_preparar_contexto_detalle(ca),
     }
     return render(request, "carrera_academica/ca_detail.html", contexto)
+
+
+@login_required
+def subir_formulario_view(request, ca_pk, formulario_pk):
+    """Endpoint POST exclusivo para subir archivo a un Formulario. Responde JSON."""
+    if request.method != "POST":
+        return JsonResponse({"ok": False, "error": "Método no permitido."}, status=405)
+
+    ca = get_object_or_404(CarreraAcademica, pk=ca_pk)
+    formulario = get_object_or_404(ca.formularios, pk=formulario_pk)
+    archivo = request.FILES.get("archivo")
+
+    if not archivo:
+        return JsonResponse({"ok": False, "error": "No se recibió ningún archivo."}, status=400)
+
+    if formulario.archivo:
+        formulario.archivo.delete(save=False)
+
+    formulario.archivo = archivo
+    formulario.estado = "ENT"
+    formulario.fecha_entrega = timezone.now().date()
+    formulario.save()
+
+    return JsonResponse({
+        "ok": True,
+        "estado": formulario.estado,
+        "fecha_entrega": formulario.fecha_entrega.strftime("%d/%m/%Y"),
+        "tipo": formulario.tipo_formulario,
+        "tipo_display": formulario.get_tipo_formulario_display(),
+    })
 
 
 @login_required


### PR DESCRIPTION
## Resumen

- Extrae la lógica de upload de archivos de `detalle_ca_view` a un nuevo endpoint dedicado `subir_formulario_view`
- `detalle_ca_view` queda exclusivamente para GET, eliminando el manejo de POST mixto
- `subir_formulario_view` responde `JsonResponse` en lugar de redirigir, habilitando fetch async

## Por qué es crítico

El POST de subida estaba embebido dentro del GET del detalle. Mientras eso existía, no era posible responder JSON a pedidos parciales sin romper la redirección. Este cambio es el prerequisito del Nivel 1 del plan de mejora de dinamismo del expediente CA.

## Cambios

- `carrera_academica/views.py`: limpieza de `detalle_ca_view` + nueva `subir_formulario_view`
- `carrera_academica/urls.py`: nueva ruta `expediente/<ca_pk>/formulario/<formulario_pk>/subir/`

## Sin cambios en modelos

No se modifican campos ni tablas de base de datos.

## Test plan

- [ ] GET a `/expediente/<pk>/` sigue renderizando el detalle correctamente
- [ ] POST a `/expediente/<ca_pk>/formulario/<formulario_pk>/subir/` con archivo devuelve `{"ok": true, ...}`
- [ ] POST sin archivo devuelve `{"ok": false, "error": "..."}` con status 400
- [ ] GET al endpoint de subida devuelve 405

🤖 Generated with [Claude Code](https://claude.com/claude-code)