### PR TITLE
feat: expediente CA dinamico — niveles 1, 2 y 3 (fetch async + modales)

### DIFF
--- a/carrera_academica/services/ca_service.py
+++ b/carrera_academica/services/ca_service.py
@@ -5,6 +5,7 @@ Servicio para workflows de Carrera Académica: finalizar y archivar.
 import logging
 from datetime import date, datetime
 
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.utils import timezone
 
@@ -60,6 +61,9 @@ class CAService:
 
                 return False, f"Resultado desconocido: {resultado}"
 
+        except ValidationError as e:
+            logger.warning(f"Validación al finalizar CA {ca.pk}: {e}")
+            return False, " ".join(e.messages)
         except Exception as e:
             logger.error(f"Error al finalizar CA {ca.pk}: {e}")
             return False, str(e)

--- a/carrera_academica/services/ca_service.py
+++ b/carrera_academica/services/ca_service.py
@@ -3,7 +3,7 @@
 Servicio para workflows de Carrera Académica: finalizar y archivar.
 """
 import logging
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from django.core.exceptions import ValidationError
 from django.db import transaction
@@ -80,7 +80,7 @@ class CAService:
             caracter=cargo.caracter,
             cantidad_horas=cargo.cantidad_horas,
             cantidad_comisiones=cargo.cantidad_comisiones,
-            fecha_inicio=timezone.now().date(),
+            fecha_inicio=ca.fecha_vencimiento_actual + timedelta(days=1),
             fecha_vencimiento=nueva_fecha_vencimiento,
             estado="activo",
             estado_continuidad="activo",

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -401,6 +401,45 @@ document.addEventListener('DOMContentLoaded', function() {
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
 
+// Iniciar evaluación via modal + fetch (inserta card HTML devuelto por la vista)
+const formIniciarEval = document.getElementById('formIniciarEvaluacion');
+if (formIniciarEval) {
+    formIniciarEval.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const btn = document.getElementById('btnConfirmarEvaluacion');
+        const errorDiv = document.getElementById('errorIniciarEval');
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Creando...';
+        errorDiv.classList.add('d-none');
+
+        fetch(formIniciarEval.action, {
+            method: 'POST',
+            body: new FormData(formIniciarEval),
+            headers: { 'X-Requested-With': 'fetch' },
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                bootstrap.Modal.getInstance(document.getElementById('modalIniciarEvaluacion')).hide();
+                const lista = document.getElementById('lista-evaluaciones');
+                lista.insertAdjacentHTML('beforeend', data.html);
+                formIniciarEval.reset();
+            } else {
+                errorDiv.textContent = data.error;
+                errorDiv.classList.remove('d-none');
+            }
+            btn.disabled = false;
+            btn.innerHTML = 'Crear Evaluación';
+        })
+        .catch(() => {
+            errorDiv.textContent = 'Error al crear la evaluación. Intente nuevamente.';
+            errorDiv.classList.remove('d-none');
+            btn.disabled = false;
+            btn.innerHTML = 'Crear Evaluación';
+        });
+    });
+}
+
 // Desvincular resolución via modal Bootstrap + fetch
 let desvinculaUrl = null;
 let desvinculaFila = null;

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -424,6 +424,18 @@ if (formIniciarEval) {
                 const lista = document.getElementById('lista-evaluaciones');
                 lista.insertAdjacentHTML('beforeend', data.html);
                 formIniciarEval.reset();
+                // Quitar del modal los años que acaban de usarse
+                if (data.anios_usados) {
+                    data.anios_usados.forEach(function(anio) {
+                        const cb = formIniciarEval.querySelector('input[value="' + anio + '"]');
+                        if (cb) cb.closest('label').remove();
+                    });
+                }
+                // Si ya no quedan checkboxes, ocultar botón e instrucción
+                if (!formIniciarEval.querySelector('input[name="anios_a_evaluar"]')) {
+                    const btnIniciar = document.querySelector('[data-bs-target="#modalIniciarEvaluacion"]');
+                    if (btnIniciar) btnIniciar.remove();
+                }
             } else {
                 errorDiv.textContent = data.error;
                 errorDiv.classList.remove('d-none');

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -379,5 +379,53 @@ document.addEventListener('DOMContentLoaded', function() {
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
+
+// Subida de archivos de formularios sin recarga
+document.addEventListener('submit', function(e) {
+    const form = e.target.closest('form.form-upload-archivo');
+    if (!form) return;
+    e.preventDefault();
+
+    const fileInput = form.querySelector('input[name="archivo"]');
+    if (!fileInput || !fileInput.files.length) return;
+
+    const btn = form.querySelector('button[type="submit"]');
+    const textoOriginal = btn.innerHTML;
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span>';
+
+    const formData = new FormData(form);
+
+    fetch(form.action, {
+        method: 'POST',
+        body: formData,
+        headers: { 'X-Requested-With': 'fetch' },
+    })
+    .then(r => r.json())
+    .then(data => {
+        if (data.ok) {
+            const row = form.closest('tr');
+            row.querySelector('[data-estado-cell]').innerHTML =
+                `<span class="badge bg-success">Entregado</span>
+                 <small class="text-muted">el ${data.fecha_entrega}</small>
+                 <a href="${data.ver_url}" target="_blank" class="btn btn-sm btn-outline-primary me-1">
+                     <i class="bi bi-file-pdf"></i> Ver
+                 </a>
+                 <a href="${data.borrar_url}" class="btn btn-sm btn-outline-danger">
+                     <i class="bi bi-trash"></i>
+                 </a>`;
+            row.querySelector('[data-accion-cell]').innerHTML = '';
+        } else {
+            alert('Error: ' + data.error);
+            btn.disabled = false;
+            btn.innerHTML = textoOriginal;
+        }
+    })
+    .catch(() => {
+        alert('Error al subir el archivo. Intente nuevamente.');
+        btn.disabled = false;
+        btn.innerHTML = textoOriginal;
+    });
+});
 </script>
 {% endblock %}

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -380,6 +380,43 @@ document.addEventListener('DOMContentLoaded', function() {
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
 
+// Agendar evaluación sin recarga
+document.addEventListener('submit', function(e) {
+    const form = e.target.closest('form.form-agendar-evaluacion');
+    if (!form) return;
+    e.preventDefault();
+
+    const btn = form.querySelector('button[type="submit"]');
+    const textoOriginal = btn.innerHTML;
+    btn.disabled = true;
+    btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span>';
+
+    fetch(form.action, {
+        method: 'POST',
+        body: new FormData(form),
+        headers: { 'X-Requested-With': 'fetch' },
+    })
+    .then(r => r.json())
+    .then(data => {
+        btn.disabled = false;
+        btn.innerHTML = textoOriginal;
+        if (data.ok) {
+            const span = form.querySelector('[data-fecha-confirmada]');
+            if (data.fecha_display) {
+                span.textContent = '✓ Agendada: ' + data.fecha_display;
+                span.classList.remove('d-none');
+            } else {
+                span.classList.add('d-none');
+            }
+        }
+    })
+    .catch(() => {
+        btn.disabled = false;
+        btn.innerHTML = textoOriginal;
+        alert('Error al agendar. Intente nuevamente.');
+    });
+});
+
 // Asignación de número de expediente sin recarga
 const formExpediente = document.querySelector('form.form-asignar-expediente');
 if (formExpediente) {

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -683,6 +683,11 @@ document.addEventListener('submit', function(e) {
     });
 });
 
+// Escapa caracteres HTML para evitar XSS al insertar datos de usuario en innerHTML
+function escapeHtml(s) {
+    return String(s).replace(/&/g,'&amp;').replace(/</g,'&lt;').replace(/>/g,'&gt;').replace(/"/g,'&quot;').replace(/'/g,'&#39;');
+}
+
 // Registrar resolución sin recarga
 const formResolucion = document.getElementById('formResolucion');
 if (formResolucion) {
@@ -715,7 +720,7 @@ if (formResolucion) {
                     let label = data.campo === 'designacion' ? 'Designación' : 'Puesta en Función';
                     fila.querySelector('td:nth-child(2)').innerHTML =
                         `<span class="badge bg-success">Asignada</span>
-                         <small class="text-muted ms-1">${data.numero}</small>
+                         <small class="text-muted ms-1">${escapeHtml(data.numero)}</small>
                          ${fileBtn}
                          <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-1 btn-desvincular"
                              data-url="${data.desvincular_url}"

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -380,6 +380,53 @@ document.addEventListener('DOMContentLoaded', function() {
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
 
+// Finalizar CA via modal + fetch
+const selectResultado = document.getElementById('selectResultadoCierre');
+if (selectResultado) {
+    selectResultado.addEventListener('change', function() {
+        const campoFecha = document.getElementById('campoNuevaFecha');
+        campoFecha.classList.toggle('d-none', this.value !== 'aprobada_redesigna');
+    });
+}
+
+const formFinalizar = document.getElementById('formFinalizar');
+if (formFinalizar) {
+    formFinalizar.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const btn = document.getElementById('btnConfirmarFinalizar');
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Finalizando...';
+
+        fetch(formFinalizar.action, {
+            method: 'POST',
+            body: new FormData(formFinalizar),
+            headers: { 'X-Requested-With': 'fetch' },
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                if (data.redesignacion) {
+                    window.location.href = data.redirect_url;
+                } else {
+                    bootstrap.Modal.getInstance(document.getElementById('modalFinalizar')).hide();
+                    document.querySelector('[data-estado-display]').textContent = data.estado_display;
+                    const acciones = document.getElementById('acciones-expediente');
+                    if (acciones) acciones.remove();
+                }
+            } else {
+                alert('Error: ' + data.error);
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-check-circle"></i> Confirmar Finalización';
+            }
+        })
+        .catch(() => {
+            alert('Error al finalizar. Intente nuevamente.');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-check-circle"></i> Confirmar Finalización';
+        });
+    });
+}
+
 // Archivar CA via modal + fetch
 const formArchivar = document.getElementById('formArchivar');
 if (formArchivar) {

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -21,7 +21,7 @@
         <table class="table table-sm table-bordered align-middle mb-0">
             <tbody>
                 {# Res. Designación #}
-                <tr>
+                <tr id="fila-resolucion-designacion">
                     <td class="fw-bold" style="width: 20%;">Res. Designación</td>
                     <td>
                         {% if ca.resolucion_designacion %}
@@ -32,13 +32,14 @@
                                     <i class="bi bi-file-pdf"></i> Ver
                                 </a>
                             {% endif %}
-                            <form action="{% url 'carrera_academica:desvincular_resolucion_ca' pk=ca.pk campo='designacion' %}" method="POST" class="d-inline ms-1">
-                                {% csrf_token %}
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"
-                                    onclick="return confirm('¿Desvincular la Resolución de Designación?')" title="Quitar">
-                                    <i class="bi bi-x"></i>
-                                </button>
-                            </form>
+                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-1 btn-desvincular"
+                                data-url="{% url 'carrera_academica:desvincular_resolucion_ca' pk=ca.pk campo='designacion' %}"
+                                data-label="Designación"
+                                data-fila="fila-resolucion-designacion"
+                                data-bs-toggle="modal" data-bs-target="#modalDesvincular"
+                                title="Quitar">
+                                <i class="bi bi-x"></i>
+                            </button>
                         {% else %}
                             <span class="badge bg-warning text-dark">Pendiente</span>
                         {% endif %}
@@ -48,7 +49,7 @@
                     </td>
                 </tr>
                 {# Res. Puesta en Función #}
-                <tr>
+                <tr id="fila-resolucion-puesta-en-funcion">
                     <td class="fw-bold">Res. Puesta en Función</td>
                     <td>
                         {% if ca.resolucion_puesta_en_funcion %}
@@ -59,13 +60,14 @@
                                     <i class="bi bi-file-pdf"></i> Ver
                                 </a>
                             {% endif %}
-                            <form action="{% url 'carrera_academica:desvincular_resolucion_ca' pk=ca.pk campo='puesta_en_funcion' %}" method="POST" class="d-inline ms-1">
-                                {% csrf_token %}
-                                <button type="submit" class="btn btn-sm btn-outline-danger py-0 px-1"
-                                    onclick="return confirm('¿Desvincular la Resolución de Puesta en Función?')" title="Quitar">
-                                    <i class="bi bi-x"></i>
-                                </button>
-                            </form>
+                            <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-1 btn-desvincular"
+                                data-url="{% url 'carrera_academica:desvincular_resolucion_ca' pk=ca.pk campo='puesta_en_funcion' %}"
+                                data-label="Puesta en Función"
+                                data-fila="fila-resolucion-puesta-en-funcion"
+                                data-bs-toggle="modal" data-bs-target="#modalDesvincular"
+                                title="Quitar">
+                                <i class="bi bi-x"></i>
+                            </button>
                         {% else %}
                             <span class="badge bg-warning text-dark">Pendiente</span>
                         {% endif %}
@@ -373,11 +375,76 @@ document.addEventListener('DOMContentLoaded', function() {
 
 {% endblock %}
 
+{# Modal compartido para desvincular resoluciones #}
+<div class="modal fade" id="modalDesvincular" tabindex="-1" aria-labelledby="modalDesvincularLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalDesvincularLabel">Confirmar</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <div class="modal-body">
+                <p id="textoDesvincular" class="mb-0"></p>
+            </div>
+            <div class="modal-footer">
+                <button type="button" class="btn btn-outline-secondary btn-sm" data-bs-dismiss="modal">Cancelar</button>
+                <button type="button" class="btn btn-danger btn-sm" id="btnConfirmarDesvincular">Quitar</button>
+            </div>
+        </div>
+    </div>
+</div>
+
 {% block extra_js %}
 <script>
 document.addEventListener('DOMContentLoaded', function() {
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
+});
+
+// Desvincular resolución via modal Bootstrap + fetch
+let desvinculaUrl = null;
+let desvinculaFila = null;
+
+document.querySelectorAll('.btn-desvincular').forEach(function(btn) {
+    btn.addEventListener('click', function() {
+        desvinculaUrl = this.dataset.url;
+        desvinculaFila = this.dataset.fila;
+        document.getElementById('textoDesvincular').textContent =
+            '¿Desvincular la Resolución de ' + this.dataset.label + '?';
+    });
+});
+
+document.getElementById('btnConfirmarDesvincular')?.addEventListener('click', function() {
+    if (!desvinculaUrl) return;
+    const btn = this;
+    btn.disabled = true;
+
+    const formData = new FormData();
+    formData.append('csrfmiddlewaretoken', document.querySelector('[name=csrfmiddlewaretoken]').value);
+
+    fetch(desvinculaUrl, {
+        method: 'POST',
+        body: formData,
+        headers: { 'X-Requested-With': 'fetch' },
+    })
+    .then(r => r.json())
+    .then(data => {
+        if (data.ok) {
+            bootstrap.Modal.getInstance(document.getElementById('modalDesvincular')).hide();
+            const fila = document.getElementById(desvinculaFila);
+            if (fila) {
+                fila.querySelector('td:nth-child(2)').innerHTML =
+                    '<span class="badge bg-warning text-dark">Pendiente</span>';
+            }
+        } else {
+            alert('Error: ' + data.error);
+        }
+        btn.disabled = false;
+    })
+    .catch(() => {
+        alert('Error al desvincular. Intente nuevamente.');
+        btn.disabled = false;
+    });
 });
 
 // Finalizar CA via modal + fetch

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -569,7 +569,22 @@ if (formArchivar) {
                 bootstrap.Modal.getInstance(document.getElementById('modalArchivar')).hide();
                 document.querySelector('[data-estado-display]').textContent = data.estado_display;
                 const acciones = document.getElementById('acciones-expediente');
-                if (acciones) acciones.remove();
+                if (acciones) {
+                    const obsHtml = data.observaciones
+                        ? `<small class="text-muted">${escapeHtml(data.observaciones)}</small><br>`
+                        : '';
+                    acciones.outerHTML =
+                        `<div class="alert alert-secondary mt-3" id="info-archivado">
+                            <strong><i class="bi bi-archive"></i> Expediente Archivado</strong><br>
+                            <small>Motivo: ${escapeHtml(data.motivo_display)}</small><br>
+                            ${obsHtml}
+                            <small class="text-muted">Archivado el ${escapeHtml(data.fecha_archivo)}</small>
+                         </div>
+                         <hr>
+                         <a href="${data.gestionar_url}" class="btn btn-warning w-100">
+                             <i class="bi bi-gear"></i> Gestionar CA Archivada
+                         </a>`;
+                }
             } else {
                 alert('Error: ' + data.error);
                 btn.disabled = false;

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -453,16 +453,17 @@ if (formIniciarEval) {
 }
 
 // Desvincular resolución via modal Bootstrap + fetch
+// Event delegation para cubrir botones insertados dinámicamente
 let desvinculaUrl = null;
 let desvinculaFila = null;
 
-document.querySelectorAll('.btn-desvincular').forEach(function(btn) {
-    btn.addEventListener('click', function() {
-        desvinculaUrl = this.dataset.url;
-        desvinculaFila = this.dataset.fila;
-        document.getElementById('textoDesvincular').textContent =
-            '¿Desvincular la Resolución de ' + this.dataset.label + '?';
-    });
+document.addEventListener('click', function(e) {
+    const btn = e.target.closest('.btn-desvincular');
+    if (!btn) return;
+    desvinculaUrl = btn.dataset.url;
+    desvinculaFila = btn.dataset.fila;
+    document.getElementById('textoDesvincular').textContent =
+        '¿Desvincular la Resolución de ' + btn.dataset.label + '?';
 });
 
 document.getElementById('btnConfirmarDesvincular')?.addEventListener('click', function() {

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -512,8 +512,10 @@ if (formFinalizar) {
     formFinalizar.addEventListener('submit', function(e) {
         e.preventDefault();
         const btn = document.getElementById('btnConfirmarFinalizar');
+        const errorDiv = document.getElementById('errorFinalizar');
         btn.disabled = true;
         btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Finalizando...';
+        errorDiv.classList.add('d-none');
 
         fetch(formFinalizar.action, {
             method: 'POST',
@@ -532,13 +534,15 @@ if (formFinalizar) {
                     if (acciones) acciones.remove();
                 }
             } else {
-                alert('Error: ' + data.error);
+                errorDiv.textContent = data.error;
+                errorDiv.classList.remove('d-none');
                 btn.disabled = false;
                 btn.innerHTML = '<i class="bi bi-check-circle"></i> Confirmar Finalización';
             }
         })
         .catch(() => {
-            alert('Error al finalizar. Intente nuevamente.');
+            errorDiv.textContent = 'Error al finalizar. Intente nuevamente.';
+            errorDiv.classList.remove('d-none');
             btn.disabled = false;
             btn.innerHTML = '<i class="bi bi-check-circle"></i> Confirmar Finalización';
         });

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -373,8 +373,6 @@ document.addEventListener('DOMContentLoaded', function() {
     </div>
 </div>
 
-{% endblock %}
-
 {# Modal compartido para desvincular resoluciones #}
 <div class="modal fade" id="modalDesvincular" tabindex="-1" aria-labelledby="modalDesvincularLabel" aria-hidden="true">
     <div class="modal-dialog modal-sm">
@@ -393,6 +391,8 @@ document.addEventListener('DOMContentLoaded', function() {
         </div>
     </div>
 </div>
+
+{% endblock %}
 
 {% block extra_js %}
 <script>

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -380,6 +380,41 @@ document.addEventListener('DOMContentLoaded', function() {
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
 
+// Archivar CA via modal + fetch
+const formArchivar = document.getElementById('formArchivar');
+if (formArchivar) {
+    formArchivar.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const btn = document.getElementById('btnConfirmarArchivar');
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Archivando...';
+
+        fetch(formArchivar.action, {
+            method: 'POST',
+            body: new FormData(formArchivar),
+            headers: { 'X-Requested-With': 'fetch' },
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                bootstrap.Modal.getInstance(document.getElementById('modalArchivar')).hide();
+                document.querySelector('[data-estado-display]').textContent = data.estado_display;
+                const acciones = document.getElementById('acciones-expediente');
+                if (acciones) acciones.remove();
+            } else {
+                alert('Error: ' + data.error);
+                btn.disabled = false;
+                btn.innerHTML = '<i class="bi bi-archive"></i> Confirmar Archivo';
+            }
+        })
+        .catch(() => {
+            alert('Error al archivar. Intente nuevamente.');
+            btn.disabled = false;
+            btn.innerHTML = '<i class="bi bi-archive"></i> Confirmar Archivo';
+        });
+    });
+}
+
 // Agendar evaluación sin recarga
 document.addEventListener('submit', function(e) {
     const form = e.target.closest('form.form-agendar-evaluacion');

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -380,6 +380,36 @@ document.addEventListener('DOMContentLoaded', function() {
     tooltipTriggerList.map(function(el) { return new bootstrap.Tooltip(el); });
 });
 
+// Asignación de número de expediente sin recarga
+const formExpediente = document.querySelector('form.form-asignar-expediente');
+if (formExpediente) {
+    formExpediente.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const formData = new FormData(formExpediente);
+        const btn = formExpediente.querySelector('button[type="submit"]');
+        btn.disabled = true;
+
+        fetch(formExpediente.action, {
+            method: 'POST',
+            body: formData,
+            headers: { 'X-Requested-With': 'fetch' },
+        })
+        .then(r => r.json())
+        .then(data => {
+            if (data.ok) {
+                document.querySelector('[data-expediente-valor]').textContent = data.numero_expediente;
+            } else {
+                alert('Error: ' + data.error);
+                btn.disabled = false;
+            }
+        })
+        .catch(() => {
+            alert('Error al asignar el expediente. Intente nuevamente.');
+            btn.disabled = false;
+        });
+    });
+}
+
 // Subida de archivos de formularios sin recarga
 document.addEventListener('submit', function(e) {
     const form = e.target.closest('form.form-upload-archivo');

--- a/carrera_academica/templates/carrera_academica/ca_detail.html
+++ b/carrera_academica/templates/carrera_academica/ca_detail.html
@@ -682,5 +682,67 @@ document.addEventListener('submit', function(e) {
         btn.innerHTML = textoOriginal;
     });
 });
+
+// Registrar resolución sin recarga
+const formResolucion = document.getElementById('formResolucion');
+if (formResolucion) {
+    formResolucion.addEventListener('submit', function(e) {
+        e.preventDefault();
+        const btn = formResolucion.querySelector('button[type="submit"]');
+        const textoOriginal = btn.innerHTML;
+        btn.disabled = true;
+        btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status"></span> Registrando...';
+
+        fetch(formResolucion.action, {
+            method: 'POST',
+            body: new FormData(formResolucion),
+            headers: { 'X-Requested-With': 'fetch' },
+        })
+        .then(r => r.json())
+        .then(data => {
+            btn.disabled = false;
+            btn.innerHTML = textoOriginal;
+            if (!data.ok) {
+                alert('Error: ' + data.error);
+                return;
+            }
+            if (data.campo === 'designacion' || data.campo === 'puesta_en_funcion') {
+                const fila = document.getElementById(data.fila_id);
+                if (fila) {
+                    let fileBtn = data.file_url
+                        ? `<a href="${data.file_url}" target="_blank" class="btn btn-sm btn-outline-primary ms-1"><i class="bi bi-file-pdf"></i> Ver</a>`
+                        : '';
+                    let label = data.campo === 'designacion' ? 'Designación' : 'Puesta en Función';
+                    fila.querySelector('td:nth-child(2)').innerHTML =
+                        `<span class="badge bg-success">Asignada</span>
+                         <small class="text-muted ms-1">${data.numero}</small>
+                         ${fileBtn}
+                         <button type="button" class="btn btn-sm btn-outline-danger py-0 px-1 ms-1 btn-desvincular"
+                             data-url="${data.desvincular_url}"
+                             data-label="${label}"
+                             data-fila="${data.fila_id}"
+                             data-bs-toggle="modal" data-bs-target="#modalDesvincular"
+                             title="Quitar"><i class="bi bi-x"></i></button>`;
+                }
+            } else if (data.campo === 'prorroga') {
+                const el = document.querySelector('[data-vencimiento-display]');
+                if (el) el.textContent = data.nueva_fecha;
+            } else if (data.campo === 'estado') {
+                const el = document.querySelector('[data-estado-display]');
+                if (el) el.textContent = data.estado_display;
+            }
+            // Colapsar el panel y resetear el formulario
+            const collapse = document.getElementById('collapseResolucionForm');
+            if (collapse) bootstrap.Collapse.getInstance(collapse)?.hide();
+            formResolucion.reset();
+            document.getElementById('campoProrroga').style.display = 'none';
+        })
+        .catch(() => {
+            btn.disabled = false;
+            btn.innerHTML = textoOriginal;
+            alert('Error al registrar la resolución. Intente nuevamente.');
+        });
+    });
+}
 </script>
 {% endblock %}

--- a/carrera_academica/templates/carrera_academica/components/ca/_evaluacion_card.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/_evaluacion_card.html
@@ -1,0 +1,32 @@
+{% load ca_extras %}
+<div class="card mt-3" id="evaluacion-card-{{ evaluacion.pk }}">
+    <div class="card-header bg-light d-flex justify-content-between align-items-center">
+        <div>
+            <strong>{{ evaluacion }}</strong>
+            <span class="fw-normal small text-muted">(Años: {{ evaluacion.anios_evaluados|join:", " }})</span>
+        </div>
+        <div>
+            <a href="{% url 'carrera_academica:notificar_junta' pk=evaluacion.pk %}" class="btn btn-primary btn-sm">
+                Notificar a Junta
+            </a>
+            <a href="{% url 'carrera_academica:editar_junta' pk=evaluacion.pk %}" class="btn btn-outline-secondary btn-sm">
+                Editar Junta
+            </a>
+        </div>
+    </div>
+    <div class="card-body">
+        <form action="{% url 'carrera_academica:agendar_evaluacion' pk=evaluacion.pk %}"
+              method="POST"
+              class="d-flex align-items-center mb-3 form-agendar-evaluacion">
+            {% csrf_token %}
+            <label class="form-label me-2 mb-0">Fecha:</label>
+            <input type="datetime-local" name="fecha_evaluacion" class="form-control form-control-sm"
+                   value="{{ evaluacion.fecha_evaluacion|date:'Y-m-d\TH:i' }}">
+            <button type="submit" class="btn btn-secondary btn-sm ms-2">Agendar</button>
+            <span class="ms-2 small text-success d-none" data-fecha-confirmada></span>
+        </form>
+
+        <h6 class="mt-3">Formularios de esta Evaluación</h6>
+        {% include 'carrera_academica/components/form_list.html' with formularios=evaluacion.formularios.all ca=ca %}
+    </div>
+</div>

--- a/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
@@ -12,7 +12,7 @@ Uso:
 
 <div class="d-flex justify-content-between align-items-center mt-4">
     <h5>Evaluaciones</h5>
-    {% if ca.estado != 'FIN' and anios_pendientes_evaluacion %}
+    {% if ca.estado == 'ACT' and anios_pendientes_evaluacion %}
         <button type="button" class="btn btn-info btn-sm"
                 data-bs-toggle="modal" data-bs-target="#modalIniciarEvaluacion">
             + Iniciar Nueva Evaluación
@@ -21,7 +21,7 @@ Uso:
 </div>
 
 {# Modal Iniciar Evaluación — se renderiza server-side con anios_pendientes_evaluacion del contexto #}
-{% if ca.estado != 'FIN' and anios_pendientes_evaluacion %}
+{% if ca.estado == 'ACT' and anios_pendientes_evaluacion %}
 <div class="modal fade" id="modalIniciarEvaluacion" tabindex="-1" aria-labelledby="modalIniciarEvalLabel" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">

--- a/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
@@ -30,37 +30,7 @@ Uso:
 {% endif %}
 
 {% for evaluacion in ca.evaluaciones.all %}
-    <div class="card mt-3">
-        <div class="card-header bg-light d-flex justify-content-between align-items-center">
-            <div>
-                <strong>{{ evaluacion }}</strong>
-                <span class="fw-normal small text-muted">(Años: {{ evaluacion.anios_evaluados|join:", " }})</span>
-            </div>
-            <div>
-                <a href="{% url 'carrera_academica:notificar_junta' pk=evaluacion.pk %}" class="btn btn-primary btn-sm">
-                    Notificar a Junta
-                </a>
-                <a href="{% url 'carrera_academica:editar_junta' pk=evaluacion.pk %}" class="btn btn-outline-secondary btn-sm">
-                    Editar Junta
-                </a>
-            </div>
-        </div>
-        <div class="card-body">
-            <form action="{% url 'carrera_academica:agendar_evaluacion' pk=evaluacion.pk %}"
-                  method="POST"
-                  class="d-flex align-items-center mb-3 form-agendar-evaluacion">
-                {% csrf_token %}
-                <label class="form-label me-2 mb-0">Fecha:</label>
-                <input type="datetime-local" name="fecha_evaluacion" class="form-control form-control-sm"
-                       value="{{ evaluacion.fecha_evaluacion|date:'Y-m-d\TH:i' }}">
-                <button type="submit" class="btn btn-secondary btn-sm ms-2">Agendar</button>
-                <span class="ms-2 small text-success d-none" data-fecha-confirmada></span>
-            </form>
-
-            <h6 class="mt-3">Formularios de esta Evaluación</h6>
-            {% include 'carrera_academica/components/form_list.html' with formularios=evaluacion.formularios.all ca=ca %}
-        </div>
-    </div>
+    {% include 'carrera_academica/components/ca/_evaluacion_card.html' with evaluacion=evaluacion ca=ca %}
 {% endfor %}
 
 {% if not ca.evaluaciones.all %}

--- a/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
@@ -13,11 +13,52 @@ Uso:
 <div class="d-flex justify-content-between align-items-center mt-4">
     <h5>Evaluaciones</h5>
     {% if ca.estado != 'FIN' and anios_pendientes_evaluacion %}
-        <a href="{% url 'carrera_academica:iniciar_evaluacion' pk=ca.pk %}" class="btn btn-info btn-sm">
+        <button type="button" class="btn btn-info btn-sm"
+                data-bs-toggle="modal" data-bs-target="#modalIniciarEvaluacion">
             + Iniciar Nueva Evaluación
-        </a>
+        </button>
     {% endif %}
 </div>
+
+{# Modal Iniciar Evaluación — se renderiza server-side con anios_pendientes_evaluacion del contexto #}
+{% if ca.estado != 'FIN' and anios_pendientes_evaluacion %}
+<div class="modal fade" id="modalIniciarEvaluacion" tabindex="-1" aria-labelledby="modalIniciarEvalLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalIniciarEvalLabel">Iniciar Nueva Evaluación</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="formIniciarEvaluacion"
+                  action="{% url 'carrera_academica:iniciar_evaluacion' pk=ca.pk %}"
+                  method="POST">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <p class="text-muted small">Seleccioná los años que cubre esta evaluación:</p>
+                    <div class="list-group list-group-flush">
+                        {% for anio in anios_pendientes_evaluacion %}
+                        <label class="list-group-item">
+                            <input class="form-check-input me-2" type="checkbox"
+                                   name="anios_a_evaluar" value="{{ anio }}">
+                            {{ anio }}
+                        </label>
+                        {% endfor %}
+                    </div>
+                    <div id="errorIniciarEval" class="alert alert-danger mt-3 d-none"></div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-info" id="btnConfirmarEvaluacion">
+                        Crear Evaluación
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endif %}
+
+<div id="lista-evaluaciones">
 
 {% if anios_pendientes_evaluacion %}
 <div class="alert alert-warning small mt-2">
@@ -36,3 +77,4 @@ Uso:
 {% if not ca.evaluaciones.all %}
     <p class="text-muted">Aún no se han iniciado evaluaciones.</p>
 {% endif %}
+</div>{# /lista-evaluaciones #}

--- a/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/evaluaciones.html
@@ -46,12 +46,15 @@ Uso:
             </div>
         </div>
         <div class="card-body">
-            <form action="{% url 'carrera_academica:agendar_evaluacion' pk=evaluacion.pk %}" method="POST" class="d-flex mb-3">
+            <form action="{% url 'carrera_academica:agendar_evaluacion' pk=evaluacion.pk %}"
+                  method="POST"
+                  class="d-flex align-items-center mb-3 form-agendar-evaluacion">
                 {% csrf_token %}
-                <label class="form-label me-2">Fecha:</label>
-                <input type="datetime-local" name="fecha_evaluacion" class="form-control form-control-sm" 
+                <label class="form-label me-2 mb-0">Fecha:</label>
+                <input type="datetime-local" name="fecha_evaluacion" class="form-control form-control-sm"
                        value="{{ evaluacion.fecha_evaluacion|date:'Y-m-d\TH:i' }}">
                 <button type="submit" class="btn btn-secondary btn-sm ms-2">Agendar</button>
+                <span class="ms-2 small text-success d-none" data-fecha-confirmada></span>
             </form>
 
             <h6 class="mt-3">Formularios de esta Evaluación</h6>

--- a/carrera_academica/templates/carrera_academica/components/ca/expediente.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/expediente.html
@@ -82,6 +82,55 @@ Uso:
     </div>
 </div>
 
+{# Modal Finalizar #}
+{% if ca.estado == 'ACT' or ca.estado == 'VEN' %}
+<div class="modal fade" id="modalFinalizar" tabindex="-1" aria-labelledby="modalFinalizarLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalFinalizarLabel"><i class="bi bi-check-circle"></i> Finalizar Expediente</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="formFinalizar"
+                  action="{% url 'carrera_academica:finalizar_ca' pk=ca.pk %}"
+                  method="POST">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">Resultado de cierre <span class="text-danger">*</span></label>
+                        <select name="resultado_cierre" class="form-select" id="selectResultadoCierre" required>
+                            <option value="">— Seleccionar —</option>
+                            {% for valor, etiqueta in resultado_choices %}
+                                <option value="{{ valor }}">{{ etiqueta }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3 d-none" id="campoNuevaFecha">
+                        <label class="form-label fw-bold">Nueva fecha de vencimiento <span class="text-danger">*</span></label>
+                        <input type="date" name="nueva_fecha_vencimiento" class="form-control">
+                        <small class="text-muted">Requerida para redesignación.</small>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Observaciones</label>
+                        <textarea name="observaciones_cierre" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="alert alert-warning small">
+                        <i class="bi bi-exclamation-triangle"></i>
+                        Esta acción cierra el expediente. Si el resultado es redesignación, se creará una nueva CA automáticamente.
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-warning" id="btnConfirmarFinalizar">
+                        <i class="bi bi-check-circle"></i> Confirmar Finalización
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endif %}
+
 {# Modal Archivar #}
 {% if ca.estado == 'ACT' or ca.estado == 'VEN' %}
 <div class="modal fade" id="modalArchivar" tabindex="-1" aria-labelledby="modalArchivarLabel" aria-hidden="true">

--- a/carrera_academica/templates/carrera_academica/components/ca/expediente.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/expediente.html
@@ -43,7 +43,7 @@ Uso:
         </p>
         
         <p class="card-text mb-1">
-            <strong>Vencimiento Actual (con prórrogas):</strong> <strong class="text-danger">{{ ca.fecha_vencimiento_actual|date:"d/m/Y" }}</strong>
+            <strong>Vencimiento Actual (con prórrogas):</strong> <strong class="text-danger" data-vencimiento-display>{{ ca.fecha_vencimiento_actual|date:"d/m/Y" }}</strong>
         </p>
         
         <p class="card-text">

--- a/carrera_academica/templates/carrera_academica/components/ca/expediente.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/expediente.html
@@ -118,6 +118,7 @@ Uso:
                         <i class="bi bi-exclamation-triangle"></i>
                         Esta acción cierra el expediente. Si el resultado es redesignación, se creará una nueva CA automáticamente.
                     </div>
+                    <div id="errorFinalizar" class="alert alert-danger d-none"></div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>

--- a/carrera_academica/templates/carrera_academica/components/ca/expediente.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/expediente.html
@@ -47,22 +47,24 @@ Uso:
         </p>
         
         <p class="card-text">
-            <strong>Estado:</strong> {{ ca.get_estado_display }}
+            <strong>Estado:</strong> <span data-estado-display>{{ ca.get_estado_display }}</span>
         </p>
-        
+
         {% if ca.estado == 'ACT' or ca.estado == 'VEN' %}
 <hr>
-<div class="d-grid gap-2">
-    <a href="{% url 'carrera_academica:finalizar_ca' pk=ca.pk %}" class="btn btn-warning">
+<div class="d-grid gap-2" id="acciones-expediente">
+    <button type="button" class="btn btn-warning"
+            data-bs-toggle="modal" data-bs-target="#modalFinalizar">
         <i class="bi bi-check-circle"></i> Finalizar Expediente
-    </a>
-    <a href="{% url 'carrera_academica:archivar_ca' pk=ca.pk %}" class="btn btn-secondary">
+    </button>
+    <button type="button" class="btn btn-secondary"
+            data-bs-toggle="modal" data-bs-target="#modalArchivar">
         <i class="bi bi-archive"></i> Archivar Expediente
-    </a>
+    </button>
 </div>
 {% endif %}
 {% if ca.estado == 'ARCH' %}
-<div class="alert alert-secondary mt-3">
+<div class="alert alert-secondary mt-3" id="info-archivado">
     <strong><i class="bi bi-archive"></i> Expediente Archivado</strong><br>
     <small>Motivo: {{ ca.get_motivo_archivo_display }}</small><br>
     {% if ca.observaciones_archivo %}
@@ -76,6 +78,50 @@ Uso:
     <i class="bi bi-gear"></i> Gestionar CA Archivada
 </a>
 {% endif %}
-        
+
     </div>
 </div>
+
+{# Modal Archivar #}
+{% if ca.estado == 'ACT' or ca.estado == 'VEN' %}
+<div class="modal fade" id="modalArchivar" tabindex="-1" aria-labelledby="modalArchivarLabel" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title" id="modalArchivarLabel"><i class="bi bi-archive"></i> Archivar Expediente</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
+            </div>
+            <form id="formArchivar"
+                  action="{% url 'carrera_academica:archivar_ca' pk=ca.pk %}"
+                  method="POST">
+                {% csrf_token %}
+                <div class="modal-body">
+                    <div class="mb-3">
+                        <label class="form-label fw-bold">Motivo de archivo <span class="text-danger">*</span></label>
+                        <select name="motivo_archivo" class="form-select" required>
+                            <option value="">— Seleccionar —</option>
+                            {% for valor, etiqueta in motivo_choices %}
+                                <option value="{{ valor }}">{{ etiqueta }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="mb-3">
+                        <label class="form-label">Observaciones</label>
+                        <textarea name="observaciones_archivo" class="form-control" rows="3"></textarea>
+                    </div>
+                    <div class="alert alert-warning small">
+                        <i class="bi bi-exclamation-triangle"></i>
+                        El expediente quedará archivado. Podrá gestionarlo luego desde "Gestionar CA Archivada".
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-outline-secondary" data-bs-dismiss="modal">Cancelar</button>
+                    <button type="submit" class="btn btn-secondary" id="btnConfirmarArchivar">
+                        <i class="bi bi-archive"></i> Confirmar Archivo
+                    </button>
+                </div>
+            </form>
+        </div>
+    </div>
+</div>
+{% endif %}

--- a/carrera_academica/templates/carrera_academica/components/ca/expediente.html
+++ b/carrera_academica/templates/carrera_academica/components/ca/expediente.html
@@ -15,15 +15,19 @@ Uso:
         
         <p class="card-text mb-1 d-flex align-items-center">
             <strong class="me-2">Expediente:</strong>
+            <span data-expediente-valor>
             {% if ca.numero_expediente %}
                 {{ ca.numero_expediente }}
             {% else %}
-                <form action="{% url 'carrera_academica:asignar_expediente' pk=ca.pk %}" method="POST" class="d-inline-flex">
+                <form action="{% url 'carrera_academica:asignar_expediente' pk=ca.pk %}"
+                      method="POST"
+                      class="d-inline-flex form-asignar-expediente">
                     {% csrf_token %}
                     {{ expediente_form.numero_expediente }}
                     <button type="submit" class="btn btn-sm btn-outline-success ms-2">Asignar</button>
                 </form>
             {% endif %}
+            </span>
         </p>
                 
         <p class="card-text mb-1">

--- a/carrera_academica/templates/carrera_academica/components/form_list.html
+++ b/carrera_academica/templates/carrera_academica/components/form_list.html
@@ -24,20 +24,20 @@ Uso:
                 {% if form.anio_correspondiente %}({{ form.anio_correspondiente }}){% endif %}
                 {% if form.evaluacion %}(Eval. {{ form.evaluacion.numero_evaluacion }}){% endif %}
             </td>
-            <td>
+            <td data-estado-cell>
                 {% if form.estado == 'ENT' %}
-                    <span class="badge bg-success">Entregado</span> 
+                    <span class="badge bg-success">Entregado</span>
                     <small class="text-muted">el {{ form.fecha_entrega|date:"d/m/Y" }}</small>
                     {% if form.archivo %}
                         <a href="{% url 'serve_private_media' path=form.archivo.name|slice:'8:' %}" target="_blank" class="btn btn-sm btn-outline-primary me-1">
                             <i class="bi bi-file-pdf"></i> Ver
                         </a>
-                        <a href="{% url 'carrera_academica:borrar_archivo_formulario' pk=form.pk %}" 
+                        <a href="{% url 'carrera_academica:borrar_archivo_formulario' pk=form.pk %}"
                            class="btn btn-sm btn-outline-danger">
                             <i class="bi bi-trash"></i>
                         </a>
                     {% else %}
-                        <a href="{% url 'carrera_academica:descargar_plantilla' pk=form.pk %}" 
+                        <a href="{% url 'carrera_academica:descargar_plantilla' pk=form.pk %}"
                            class="btn btn-sm btn-outline-secondary">
                             <i class="bi bi-download"></i> Plantilla
                         </a>
@@ -48,13 +48,15 @@ Uso:
                     <span class="badge bg-warning text-dark">Pendiente</span>
                 {% endif %}
             </td>
-            <td style="width: 45%;">
+            <td style="width: 45%;" data-accion-cell>
                 {% if ca.estado != 'FIN' %}
                     {% if form.estado == 'PEN' or form.tipo_formulario == 'CV' %}
                     <div class="d-flex">
-                        <form method="POST" enctype="multipart/form-data" class="d-flex flex-grow-1">
+                        <form method="POST"
+                              action="{% url 'carrera_academica:subir_formulario' ca_pk=ca.pk formulario_pk=form.pk %}"
+                              enctype="multipart/form-data"
+                              class="d-flex flex-grow-1 form-upload-archivo">
                             {% csrf_token %}
-                            <input type="hidden" name="formulario_id" value="{{ form.pk }}">
                             <input type="file" name="archivo" class="form-control form-control-sm" required>
                             <button type="submit" class="btn btn-primary btn-sm ms-2">
                                 {% if form.estado == 'ENT' %}Actualizar{% else %}Subir{% endif %}

--- a/carrera_academica/urls.py
+++ b/carrera_academica/urls.py
@@ -60,6 +60,11 @@ urlpatterns = [
     path('ca/<int:pk>/archivar/', views.archivar_ca_view, name='archivar_ca'),
     path('ca/<int:pk>/gestionar-archivada/', views.gestionar_ca_archivada_view, name='gestionar_ca_archivada'),
     path('formulario/<int:pk>/borrar-archivo/', views.borrar_archivo_formulario_view, name='borrar_archivo_formulario'),
+    path(
+        'expediente/<int:ca_pk>/formulario/<int:formulario_pk>/subir/',
+        views.subir_formulario_view,
+        name='subir_formulario',
+    ),
     # ===== JURADOS =====
     path('jurados/', views.lista_jurados_view, name='lista_jurados'),
     path('jurados/crear/', views.crear_jurado_view, name='crear_jurado'),

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -196,26 +196,6 @@ def dashboard_ca_view(request):
 @login_required
 def detalle_ca_view(request, pk):
     ca = get_object_or_404(CarreraAcademica.objects.with_full_detail(), pk=pk)
-
-    if request.method == "POST":
-        formulario_id = request.POST.get("formulario_id")
-        archivo = request.FILES.get("archivo")
-
-        if formulario_id and archivo:
-            formulario = ca.formularios.get(pk=formulario_id)
-            if formulario.archivo:
-                formulario.archivo.delete(save=False)
-            formulario.archivo = archivo
-            formulario.estado = "ENT"
-            formulario.fecha_entrega = timezone.now()
-            formulario.save()
-            messages.success(
-                request,
-                f"Se subió el archivo para el formulario {formulario.tipo_formulario}.",
-            )
-
-        return redirect("carrera_academica:detalle_ca", pk=ca.pk)
-
     contexto = {
         "ca": ca,
         "form_resolucion": ResolucionForm(),
@@ -223,6 +203,36 @@ def detalle_ca_view(request, pk):
         **_preparar_contexto_detalle(ca),
     }
     return render(request, "carrera_academica/ca_detail.html", contexto)
+
+
+@login_required
+def subir_formulario_view(request, ca_pk, formulario_pk):
+    """Endpoint POST exclusivo para subir archivo a un Formulario. Responde JSON."""
+    if request.method != "POST":
+        return JsonResponse({"ok": False, "error": "Método no permitido."}, status=405)
+
+    ca = get_object_or_404(CarreraAcademica, pk=ca_pk)
+    formulario = get_object_or_404(ca.formularios, pk=formulario_pk)
+    archivo = request.FILES.get("archivo")
+
+    if not archivo:
+        return JsonResponse({"ok": False, "error": "No se recibió ningún archivo."}, status=400)
+
+    if formulario.archivo:
+        formulario.archivo.delete(save=False)
+
+    formulario.archivo = archivo
+    formulario.estado = "ENT"
+    formulario.fecha_entrega = timezone.now().date()
+    formulario.save()
+
+    return JsonResponse({
+        "ok": True,
+        "estado": formulario.estado,
+        "fecha_entrega": formulario.fecha_entrega.strftime("%d/%m/%Y"),
+        "tipo": formulario.tipo_formulario,
+        "tipo_display": formulario.get_tipo_formulario_display(),
+    })
 
 
 @login_required

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -349,6 +349,7 @@ def iniciar_evaluacion_view(request, pk):
 @login_required
 def registrar_resolucion_view(request, pk):
     ca = get_object_or_404(CarreraAcademica, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
     if request.method == "POST":
         form = ResolucionForm(request.POST, request.FILES)
@@ -361,21 +362,52 @@ def registrar_resolucion_view(request, pk):
 
             if objeto in ["alta", "redesignacion", "designacion"]:
                 ca.resolucion_designacion = nueva_resolucion
-                messages.info(
-                    request, "La resolución se ha vinculado como 'Designación'.")
+                ca.save()
+                if es_fetch:
+                    from django.urls import reverse
+                    return JsonResponse({
+                        "ok": True,
+                        "campo": "designacion",
+                        "fila_id": "fila-resolucion-designacion",
+                        "numero": str(nueva_resolucion),
+                        "desvincular_url": reverse("carrera_academica:desvincular_resolucion_ca", kwargs={"pk": ca.pk, "campo": "designacion"}),
+                        "file_url": reverse("serve_private_media", kwargs={"path": nueva_resolucion.file.name[8:]}) if nueva_resolucion.file else None,
+                        "mensaje": "La resolución se ha vinculado como 'Designación'.",
+                    })
+                messages.info(request, "La resolución se ha vinculado como 'Designación'.")
 
             elif objeto == "puesta_funcion":
                 ca.resolucion_puesta_en_funcion = nueva_resolucion
-                messages.info(
-                    request, "La resolución se ha vinculado como 'Puesta en Función'.")
+                ca.save()
+                if es_fetch:
+                    from django.urls import reverse
+                    return JsonResponse({
+                        "ok": True,
+                        "campo": "puesta_en_funcion",
+                        "fila_id": "fila-resolucion-puesta-en-funcion",
+                        "numero": str(nueva_resolucion),
+                        "desvincular_url": reverse("carrera_academica:desvincular_resolucion_ca", kwargs={"pk": ca.pk, "campo": "puesta_en_funcion"}),
+                        "file_url": reverse("serve_private_media", kwargs={"path": nueva_resolucion.file.name[8:]}) if nueva_resolucion.file else None,
+                        "mensaje": "La resolución se ha vinculado como 'Puesta en Función'.",
+                    })
+                messages.info(request, "La resolución se ha vinculado como 'Puesta en Función'.")
 
             elif objeto == "prorroga_ca":
                 exito, mensaje = CAService.aplicar_prorroga(
                     ca,
-                    nueva_fecha=form.cleaned_data.get(
-                        "nueva_fecha_vencimiento"),
+                    nueva_fecha=form.cleaned_data.get("nueva_fecha_vencimiento"),
                     dias=form.cleaned_data.get("prorroga_dias"),
                 )
+                if es_fetch:
+                    if exito:
+                        ca.refresh_from_db()
+                        return JsonResponse({
+                            "ok": True,
+                            "campo": "prorroga",
+                            "nueva_fecha": ca.fecha_vencimiento_actual.strftime("%d/%m/%Y"),
+                            "mensaje": mensaje,
+                        })
+                    return JsonResponse({"ok": False, "error": mensaje}, status=400)
                 if exito:
                     messages.success(request, mensaje)
                 else:
@@ -384,15 +416,35 @@ def registrar_resolucion_view(request, pk):
 
             elif objeto == "licencia_alta":
                 ca.estado = "STB"
+                ca.save()
+                if es_fetch:
+                    return JsonResponse({
+                        "ok": True,
+                        "campo": "estado",
+                        "estado_display": ca.get_estado_display(),
+                        "mensaje": f"Resolución de '{nueva_resolucion.get_objeto_display()}' registrada.",
+                    })
 
             elif objeto == "licencia_baja":
                 ca.estado = "ACT"
+                ca.save()
+                if es_fetch:
+                    return JsonResponse({
+                        "ok": True,
+                        "campo": "estado",
+                        "estado_display": ca.get_estado_display(),
+                        "mensaje": f"Resolución de '{nueva_resolucion.get_objeto_display()}' registrada.",
+                    })
+            else:
+                ca.save()
 
-            ca.save()
             messages.success(
                 request,
                 f"Resolución de '{nueva_resolucion.get_objeto_display()}' registrada exitosamente.",
             )
+        elif es_fetch:
+            errores = {f: e.as_text() for f, e in form.errors.items()}
+            return JsonResponse({"ok": False, "error": "Datos inválidos.", "errores": errores}, status=400)
 
     return redirect("carrera_academica:detalle_ca", pk=ca.pk)
 

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -226,12 +226,18 @@ def subir_formulario_view(request, ca_pk, formulario_pk):
     formulario.fecha_entrega = timezone.now().date()
     formulario.save()
 
+    from django.urls import reverse
+    ver_url = reverse("serve_private_media", kwargs={"path": formulario.archivo.name[8:]})
+    borrar_url = reverse("carrera_academica:borrar_archivo_formulario", kwargs={"pk": formulario.pk})
+
     return JsonResponse({
         "ok": True,
         "estado": formulario.estado,
         "fecha_entrega": formulario.fecha_entrega.strftime("%d/%m/%Y"),
         "tipo": formulario.tipo_formulario,
         "tipo_display": formulario.get_tipo_formulario_display(),
+        "ver_url": ver_url,
+        "borrar_url": borrar_url,
     })
 
 
@@ -524,12 +530,14 @@ def desvincular_resolucion_ca_view(request, pk, campo):
 def asignar_expediente_view(request, pk):
     ca = get_object_or_404(CarreraAcademica, pk=pk)
     if request.method == "POST":
-        # Pasamos la instancia existente para que el formulario la actualice
         form = ExpedienteForm(request.POST, instance=ca)
         if form.is_valid():
             form.save()
+            if request.headers.get("X-Requested-With") == "fetch":
+                return JsonResponse({"ok": True, "numero_expediente": ca.numero_expediente})
             messages.success(request, "Número de expediente actualizado correctamente.")
-    # Siempre redirigimos de vuelta al detalle
+        elif request.headers.get("X-Requested-With") == "fetch":
+            return JsonResponse({"ok": False, "error": "Número de expediente inválido."}, status=400)
     return redirect("carrera_academica:detalle_ca", pk=ca.pk)
 
 

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -748,32 +748,34 @@ def notificar_junta_view(request, pk):
 
 @login_required
 def agendar_evaluacion_view(request, pk):
-    # El 'pk' que recibimos es el de la Evaluación
     evaluacion = get_object_or_404(Evaluacion, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
-    # Esta acción solo debe ocurrir si se envía el formulario
     if request.method == "POST":
-        # Obtenemos el valor del campo 'fecha_evaluacion' del formulario
         fecha_str = request.POST.get("fecha_evaluacion")
 
         if fecha_str:
-            # Si se proporcionó una fecha, la guardamos en el objeto Evaluacion
             evaluacion.fecha_evaluacion = fecha_str
             evaluacion.save()
+            if es_fetch:
+                return JsonResponse({
+                    "ok": True,
+                    "fecha_display": evaluacion.fecha_evaluacion.strftime("%d/%m/%Y %H:%M"),
+                })
             messages.success(
                 request,
                 f"Se agendó la fecha para la Evaluación N°{evaluacion.numero_evaluacion}.",
             )
         else:
-            # Si se envía el campo vacío, borramos la fecha
             evaluacion.fecha_evaluacion = None
             evaluacion.save()
+            if es_fetch:
+                return JsonResponse({"ok": True, "fecha_display": None})
             messages.info(
                 request,
                 f"Se ha quitado la fecha para la Evaluación N°{evaluacion.numero_evaluacion}.",
             )
 
-    # Sin importar qué pase, siempre redirigimos de vuelta a la página del expediente
     return redirect("carrera_academica:detalle_ca", pk=evaluacion.carrera_academica.pk)
 
 

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -246,10 +246,13 @@ def subir_formulario_view(request, ca_pk, formulario_pk):
 @login_required
 def iniciar_evaluacion_view(request, pk):
     ca = get_object_or_404(CarreraAcademica, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
     # Verificar si se puede iniciar evaluación
     puede, razon = ca.puede_iniciar_evaluacion()
     if not puede:
+        if es_fetch:
+            return JsonResponse({"ok": False, "error": f"No se puede iniciar evaluación: {razon}"}, status=400)
         messages.error(request, f"No se puede iniciar evaluación: {razon}")
         return redirect("carrera_academica:detalle_ca", pk=ca.pk)
 
@@ -276,26 +279,18 @@ def iniciar_evaluacion_view(request, pk):
             try:
                 anios_seleccionados = form.cleaned_data["anios_a_evaluar"]
 
-                # Obtener el siguiente número de evaluación
-                from django.db.models import Max
-
-                max_eval = ca.evaluaciones.aggregate(max_num=Max("numero_evaluacion"))[
-                    "max_num"
-                ]
+                max_eval = ca.evaluaciones.aggregate(max_num=Max("numero_evaluacion"))["max_num"]
                 nuevo_num = (max_eval or 0) + 1
 
-                # Crear la nueva evaluación
                 nueva_evaluacion = Evaluacion(
                     carrera_academica=ca,
                     numero_evaluacion=nuevo_num,
                     anios_evaluados=[int(a) for a in anios_seleccionados],
                 )
 
-                # Validar antes de guardar
                 nueva_evaluacion.full_clean()
                 nueva_evaluacion.save()
 
-                # Crear los formularios asociados
                 for tipo in ["F08", "F09", "F10", "F11", "F12"]:
                     Formulario.objects.create(
                         carrera_academica=ca,
@@ -303,7 +298,6 @@ def iniciar_evaluacion_view(request, pk):
                         evaluacion=nueva_evaluacion,
                     )
 
-                es_fetch = request.headers.get("X-Requested-With") == "fetch"
                 if es_fetch:
                     from django.template.loader import render_to_string
                     descripciones_formularios = {
@@ -315,7 +309,11 @@ def iniciar_evaluacion_view(request, pk):
                          "descripciones_formularios": descripciones_formularios},
                         request=request,
                     )
-                    return JsonResponse({"ok": True, "html": html})
+                    return JsonResponse({
+                        "ok": True,
+                        "html": html,
+                        "anios_usados": [int(a) for a in anios_seleccionados],
+                    })
 
                 messages.success(
                     request,
@@ -325,18 +323,21 @@ def iniciar_evaluacion_view(request, pk):
 
             except ValidationError as e:
                 logger.warning(f"Error de validación al crear evaluación: {e}")
-                if request.headers.get("X-Requested-With") == "fetch":
+                if es_fetch:
                     return JsonResponse({"ok": False, "error": " ".join(e.messages)}, status=400)
                 for error in e.messages:
                     messages.error(request, error)
 
             except Exception as e:
                 logger.error(f"Error inesperado al crear evaluación: {e}")
-                if request.headers.get("X-Requested-With") == "fetch":
+                if es_fetch:
                     return JsonResponse({"ok": False, "error": "Error al crear la evaluación."}, status=500)
                 messages.error(
                     request, "Error al crear la evaluación. Contacte al administrador."
                 )
+        elif es_fetch:
+            errores = form.errors.get("anios_a_evaluar", ["Seleccioná al menos un año."])
+            return JsonResponse({"ok": False, "error": errores[0] if errores else "Formulario inválido."}, status=400)
     else:
         form = EvaluacionForm()
         form.fields["anios_a_evaluar"].choices = [(y, y) for y in anios_pendientes]

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -511,6 +511,7 @@ def desvincular_resolucion_ca_view(request, pk, campo):
         return redirect("carrera_academica:detalle_ca", pk=pk)
 
     ca = get_object_or_404(CarreraAcademica, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
     campos_validos = {
         "designacion": ("resolucion_designacion", "Designación"),
@@ -518,12 +519,16 @@ def desvincular_resolucion_ca_view(request, pk, campo):
     }
 
     if campo not in campos_validos:
+        if es_fetch:
+            return JsonResponse({"ok": False, "error": "Campo no válido."}, status=400)
         messages.error(request, "Campo no válido.")
         return redirect("carrera_academica:detalle_ca", pk=pk)
 
     field_name, label = campos_validos[campo]
     setattr(ca, field_name, None)
     ca.save(update_fields=[field_name])
+    if es_fetch:
+        return JsonResponse({"ok": True, "label": label})
     messages.success(request, f"Resolución de {label} desvinculada correctamente.")
     return redirect("carrera_academica:detalle_ca", pk=pk)
 

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -595,12 +595,15 @@ def docentes_filtrados_api_view(request):
 @login_required
 def finalizar_ca_view(request, pk):
     ca = get_object_or_404(CarreraAcademica, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
     if request.method == "POST":
         resultado = request.POST.get("resultado_cierre")
         observaciones = request.POST.get("observaciones_cierre", "")
 
         if not resultado:
+            if es_fetch:
+                return JsonResponse({"ok": False, "error": "Debe seleccionar un resultado de cierre."}, status=400)
             messages.error(request, "Debe seleccionar un resultado de cierre")
             return redirect("carrera_academica:finalizar_ca", pk=pk)
 
@@ -610,6 +613,8 @@ def finalizar_ca_view(request, pk):
             try:
                 nueva_fecha = datetime.strptime(fecha_str, "%Y-%m-%d").date()
             except (ValueError, TypeError):
+                if es_fetch:
+                    return JsonResponse({"ok": False, "error": "Formato de fecha inválido."}, status=400)
                 messages.error(request, "Formato de fecha inválido")
                 return redirect("carrera_academica:finalizar_ca", pk=pk)
 
@@ -617,16 +622,31 @@ def finalizar_ca_view(request, pk):
             ca, resultado, observaciones, nueva_fecha, request.user)
 
         if not exito:
+            if es_fetch:
+                return JsonResponse({"ok": False, "error": mensaje}, status=400)
             messages.error(request, mensaje)
             return redirect("carrera_academica:finalizar_ca", pk=pk)
 
-        # Redesignación: redirigir a la nueva CA
+        # Redesignación: crear nueva CA y redirigir
         if mensaje.startswith("redesignacion:"):
+            from django.urls import reverse
             nueva_ca_pk = mensaje.split(":")[1]
-            messages.success(
-                request, f"CA finalizada y redesignada. Nuevo expediente #{nueva_ca_pk} creado.")
+            if es_fetch:
+                return JsonResponse({
+                    "ok": True,
+                    "redesignacion": True,
+                    "redirect_url": reverse("carrera_academica:detalle_ca", kwargs={"pk": nueva_ca_pk}),
+                    "mensaje": f"CA finalizada y redesignada. Nuevo expediente #{nueva_ca_pk} creado.",
+                })
+            messages.success(request, f"CA finalizada y redesignada. Nuevo expediente #{nueva_ca_pk} creado.")
             return redirect("carrera_academica:detalle_ca", pk=nueva_ca_pk)
 
+        if es_fetch:
+            return JsonResponse({
+                "ok": True,
+                "estado_display": ca.get_estado_display(),
+                "mensaje": f"Expediente finalizado: {mensaje}",
+            })
         messages.success(request, f"Expediente finalizado: {mensaje}")
         return redirect("carrera_academica:detalle_ca", pk=pk)
 

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -854,6 +854,7 @@ def agendar_evaluacion_view(request, pk):
         if fecha_str:
             evaluacion.fecha_evaluacion = fecha_str
             evaluacion.save()
+            evaluacion.refresh_from_db()
             if es_fetch:
                 return JsonResponse({
                     "ok": True,

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -303,6 +303,20 @@ def iniciar_evaluacion_view(request, pk):
                         evaluacion=nueva_evaluacion,
                     )
 
+                es_fetch = request.headers.get("X-Requested-With") == "fetch"
+                if es_fetch:
+                    from django.template.loader import render_to_string
+                    descripciones_formularios = {
+                        tf.codigo: tf.descripcion for tf in TipoFormulario.objects.all()
+                    }
+                    html = render_to_string(
+                        "carrera_academica/components/ca/_evaluacion_card.html",
+                        {"evaluacion": nueva_evaluacion, "ca": ca,
+                         "descripciones_formularios": descripciones_formularios},
+                        request=request,
+                    )
+                    return JsonResponse({"ok": True, "html": html})
+
                 messages.success(
                     request,
                     f"Evaluación N°{nuevo_num} creada, cubriendo los años {', '.join(anios_seleccionados)}.",
@@ -311,11 +325,15 @@ def iniciar_evaluacion_view(request, pk):
 
             except ValidationError as e:
                 logger.warning(f"Error de validación al crear evaluación: {e}")
+                if request.headers.get("X-Requested-With") == "fetch":
+                    return JsonResponse({"ok": False, "error": " ".join(e.messages)}, status=400)
                 for error in e.messages:
                     messages.error(request, error)
 
             except Exception as e:
                 logger.error(f"Error inesperado al crear evaluación: {e}")
+                if request.headers.get("X-Requested-With") == "fetch":
+                    return JsonResponse({"ok": False, "error": "Error al crear la evaluación."}, status=500)
                 messages.error(
                     request, "Error al crear la evaluación. Contacte al administrador."
                 )

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -1094,10 +1094,14 @@ def archivar_ca_view(request, pk):
 
         if exito:
             if es_fetch:
+                from django.urls import reverse
                 return JsonResponse({
                     "ok": True,
                     "estado_display": ca.get_estado_display(),
                     "motivo_display": ca.get_motivo_archivo_display(),
+                    "observaciones": ca.observaciones_archivo or "",
+                    "fecha_archivo": ca.fecha_archivo.strftime("%d/%m/%Y %H:%M"),
+                    "gestionar_url": reverse("carrera_academica:gestionar_ca_archivada", kwargs={"pk": ca.pk}),
                 })
             messages.success(request, mensaje)
             return redirect("carrera_academica:detalle_ca", pk=pk)

--- a/carrera_academica/views.py
+++ b/carrera_academica/views.py
@@ -200,6 +200,8 @@ def detalle_ca_view(request, pk):
         "ca": ca,
         "form_resolucion": ResolucionForm(),
         "expediente_form": ExpedienteForm(instance=ca),
+        "motivo_choices": CarreraAcademica.MOTIVO_ARCHIVO_CHOICES,
+        "resultado_choices": CarreraAcademica.RESULTADO_CIERRE_CHOICES,
         **_preparar_contexto_detalle(ca),
     }
     return render(request, "carrera_academica/ca_detail.html", contexto)
@@ -979,21 +981,32 @@ def gestionar_formularios_anio_view(request, pk, anio):
 @login_required
 def archivar_ca_view(request, pk):
     ca = get_object_or_404(CarreraAcademica, pk=pk)
+    es_fetch = request.headers.get("X-Requested-With") == "fetch"
 
     if request.method == "POST":
         motivo = request.POST.get("motivo_archivo")
         observaciones = request.POST.get("observaciones_archivo", "")
 
         if not motivo:
+            if es_fetch:
+                return JsonResponse({"ok": False, "error": "Debe seleccionar un motivo de archivo."}, status=400)
             messages.error(request, "Debe seleccionar un motivo de archivo")
             return redirect("carrera_academica:archivar_ca", pk=pk)
 
         exito, mensaje = CAService.archivar(ca, motivo, observaciones)
 
         if exito:
+            if es_fetch:
+                return JsonResponse({
+                    "ok": True,
+                    "estado_display": ca.get_estado_display(),
+                    "motivo_display": ca.get_motivo_archivo_display(),
+                })
             messages.success(request, mensaje)
             return redirect("carrera_academica:detalle_ca", pk=pk)
         else:
+            if es_fetch:
+                return JsonResponse({"ok": False, "error": mensaje}, status=400)
             messages.error(request, mensaje)
             return redirect("carrera_academica:archivar_ca", pk=pk)
 

--- a/planta_docente/models.py
+++ b/planta_docente/models.py
@@ -1,5 +1,6 @@
 from django.core.exceptions import ValidationError
 from django.db import models
+from django.db.models import Q
 from django.db.models.signals import pre_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -1544,29 +1545,22 @@ class Cargo(models.Model):
             )
 
         # Validación: unidades de dedicación no pueden superar 5
+        # Se evalúa contra la fecha de inicio del cargo (no "hoy"), para que un cargo
+        # futuro no choque con uno que ya venció para esa fecha (ej: redesignación).
         if self.caracter not in self.CARACTERES_SIN_UNIDADES and self.estado == 'activo':
-            unidades_cargo_actual = self.UNIDADES_DEDICACION.get(self.dedicacion, 0)*self.cantidad_dedicaciones
+            check_date = self.fecha_inicio if self.fecha_inicio else timezone.now().date()
+            unidades_cargo_actual = self.UNIDADES_DEDICACION.get(self.dedicacion, 0) * self.cantidad_dedicaciones
 
             cargos_activos = Cargo.objects.filter(
                 docente=self.docente,
                 estado='activo',
+                fecha_inicio__lte=check_date,
+            ).filter(
+                Q(fecha_vencimiento__isnull=True) | Q(fecha_vencimiento__gte=check_date)
             ).exclude(pk=self.pk).exclude(caracter__in=self.CARACTERES_SIN_UNIDADES)
 
             unidades_ocupadas = sum(
-                self.UNIDADES_DEDICACION.get(c.dedicacion, 0)*c.cantidad_dedicaciones  for c in cargos_activos
-            )
-
-        # Validación: unidades de dedicación no pueden superar 5
-        if self.caracter not in self.CARACTERES_SIN_UNIDADES and self.estado == 'activo':
-            unidades_cargo_actual = self.UNIDADES_DEDICACION.get(self.dedicacion, 0)*self.cantidad_dedicaciones
-
-            cargos_activos = Cargo.objects.filter(
-                docente=self.docente,
-                estado='activo',
-            ).exclude(pk=self.pk).exclude(caracter__in=self.CARACTERES_SIN_UNIDADES)
-
-            unidades_ocupadas = sum(
-                self.UNIDADES_DEDICACION.get(c.dedicacion, 0)*c.cantidad_dedicaciones  for c in cargos_activos
+                self.UNIDADES_DEDICACION.get(c.dedicacion, 0) * c.cantidad_dedicaciones for c in cargos_activos
             )
 
             if unidades_ocupadas + unidades_cargo_actual > self.MAX_UNIDADES:


### PR DESCRIPTION
## Resumen

Reemplaza navegaciones y recargas completas en la gestión del expediente de Carrera Académica por interacciones inline con fetch + modales Bootstrap.

### Nivel crítico — Refactor base
- Extrae la subida de archivos de `detalle_ca_view` a `subir_formulario_view` dedicado

### Nivel 1 — Acciones sin recarga
- Asignación de número de expediente inline
- Agendado de fecha de evaluación inline
- Desvincular resolución vía modal Bootstrap compartido (event delegation para botones dinámicos)

### Nivel 2 — Modales para acciones destructivas
- Finalizar expediente vía modal (incluye redesignación con redirect automático)
- Archivar expediente vía modal (muestra bloque "Expediente Archivado" inline con botón Gestionar)
- Iniciar evaluación vía modal con checkboxes server-side; actualiza lista y quita años usados del modal

### Nivel 3 — Registrar resolución y subida de archivos
- Subida de formularios sin recarga con actualización de celdas de estado/acción
- Registrar resolución inline: designación, puesta en función, prórroga (actualiza fecha vencimiento), licencia (actualiza estado)

### Bugs corregidos en QA
- `agendar_evaluacion_view`: `refresh_from_db()` antes de `.strftime()` para evitar 500
- Modal `#modalDesvincular` estaba fuera del bloque `ca_content` y Django lo descartaba
- `iniciar_evaluacion_view`: JSON en todos los paths de error fetch; condición del botón alineada a `estado == ACT`; modal actualiza checkboxes tras crear evaluación
- Error de validación en redesignación se mostraba como repr de dict Python; fix con `e.messages`
- Nuevo cargo de redesignación arranca desde `fecha_vencimiento_actual + 1 día`; validación de dedicación usa fechas del cargo para no contar cargos ya vencidos
- Bloque "Expediente Archivado" se inyecta inline tras archivar sin recargar
- XSS: `data.numero` escapado con `escapeHtml()` antes de insertar en `innerHTML`

## Test plan

- [ ] Asignar expediente → número aparece sin recarga
- [ ] Agendar evaluación → confirmación inline
- [ ] Desvincular resolución (original y recién registrada) → modal + badge Pendiente
- [ ] Registrar resolución Designación/Puesta en Función → fila actualizada inline
- [ ] Registrar resolución Prórroga → fecha vencimiento actualizada
- [ ] Iniciar evaluación → card nueva en lista, años usados removidos del modal
- [ ] Finalizar → sin redesignación: estado actualizado; con redesignación: redirect a nueva CA
- [ ] Archivar → bloque "Expediente Archivado" + botón Gestionar visibles sin recarga
- [ ] Subir archivo de formulario → celda estado/acción actualizada

🤖 Generated with [Claude Code](https://claude.com/claude-code)